### PR TITLE
Fix content loading by respecting Vite base URL

### DIFF
--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -3,9 +3,13 @@ import type { RevisionContent } from '../types';
 /**
  * Load revision content from JSON file
  */
-export async function loadRevisionContent(path: string = '/data/cscs-questions.json'): Promise<RevisionContent> {
+export async function loadRevisionContent(path: string = 'data/cscs-questions.json'): Promise<RevisionContent> {
   try {
-    const response = await fetch(path);
+    // Construct the full path using Vite's base URL
+    const baseUrl = import.meta.env.BASE_URL;
+    const fullPath = `${baseUrl}${path}`;
+
+    const response = await fetch(fullPath);
     if (!response.ok) {
       throw new Error(`Failed to load content: ${response.statusText}`);
     }


### PR DESCRIPTION
- Update contentLoader to use import.meta.env.BASE_URL when fetching data files
- This ensures the correct path is used when deployed to GitHub Pages with a base URL of /cscs-card-audio-revision/
- Fixes error: "Failed to load revision content"

The issue was that the fetch was using an absolute path /data/cscs-questions.json which doesn't work when the app is deployed to a subdirectory. Now it correctly constructs the full path using the BASE_URL env variable.